### PR TITLE
feat: 모집글 페이지 검색 api의 url에서 eventId에 대한 종속을 제거

### DIFF
--- a/src/main/java/com/BaGulBaGul/BaGulBaGul/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/BaGulBaGul/BaGulBaGul/domain/recruitment/controller/RecruitmentController.java
@@ -17,7 +17,6 @@ public interface RecruitmentController {
     ApiResponse<RecruitmentDetailResponse> getRecruitmentById(Long recruitmentId);
 
     ApiResponse<Page<RecruitmentSimpleResponse>> getRecruitmentPageByCondition(
-            Long eventId,
             RecruitmentConditionalApiRequest recruitmentConditionalRequest,
             Pageable pageable
     );

--- a/src/main/java/com/BaGulBaGul/BaGulBaGul/domain/recruitment/controller/RecruitmentControllerImpl.java
+++ b/src/main/java/com/BaGulBaGul/BaGulBaGul/domain/recruitment/controller/RecruitmentControllerImpl.java
@@ -50,23 +50,22 @@ public class RecruitmentControllerImpl implements RecruitmentController {
     }
 
     @Override
-    @GetMapping("/{eventId}/recruitment")
+    @GetMapping("/recruitment")
     @Operation(summary = "어떤 이벤트에 속하면서 주어진 조건에 맞는 모집글을 페이징 조회",
             description = "페이징 관련 파라메터는 \n "
-                    + "http://localhost:8080/api/event/7/recruitment?size=10&page=0&sort=likeCount,desc&sort=views,asc \n "
+                    + "http://localhost:8080/api/event/recruitment?eventId=7&size=10&page=0&sort=likeCount,desc&sort=views,asc \n "
                     + "이런 식으로 넘기면 됨 \n "
                     + "sort가 여러 개면 앞에서부터 순서대로 정렬 적용\n"
                     + "파라메터로 명시하지 않은 조건은 무시되지만 페이징은 기본 페이징 조건 적용됨(page 0 size 20)\n"
                     + "정렬 가능 속성 : createdAt, views, likeCount, commentCount, startDate, endDate, headCount"
     )
     public ApiResponse<Page<RecruitmentSimpleResponse>> getRecruitmentPageByCondition(
-            @PathVariable(name = "eventId") Long eventId,
             RecruitmentConditionalApiRequest recruitmentConditionalApiRequest,
             Pageable pageable
     ) {
         return ApiResponse.of(
             recruitmentService.getRecruitmentPageByCondition(
-                    recruitmentConditionalApiRequest.toRecruitmentConditionalRequest(eventId),
+                    recruitmentConditionalApiRequest.toRecruitmentConditionalRequest(),
                     pageable
             )
         );

--- a/src/main/java/com/BaGulBaGul/BaGulBaGul/domain/recruitment/dto/RecruitmentConditionalApiRequest.java
+++ b/src/main/java/com/BaGulBaGul/BaGulBaGul/domain/recruitment/dto/RecruitmentConditionalApiRequest.java
@@ -15,6 +15,9 @@ import lombok.Setter;
 @AllArgsConstructor
 public class RecruitmentConditionalApiRequest {
 
+    @ApiModelProperty(value = "모집글이 속한 이벤트의 id")
+    private Long eventId;
+
     @ApiModelProperty(value = "게시글 제목")
     private String title;
 
@@ -27,7 +30,7 @@ public class RecruitmentConditionalApiRequest {
     @ApiModelProperty(value = "남은 인원 수")
     private Integer leftHeadCount;
 
-    public RecruitmentConditionalRequest toRecruitmentConditionalRequest(Long eventId) {
+    public RecruitmentConditionalRequest toRecruitmentConditionalRequest() {
         return RecruitmentConditionalRequest.builder()
                 .eventId(eventId)
                 .title(title)


### PR DESCRIPTION
기존에는 path parameter로 받았기 때문에 특정 이벤트에 대한 recruitment만 조회 가능했다. 이것을 query parameter로 변경해서 모든 recruitment에 대해 조회 가능하도록 변경